### PR TITLE
AB#115566 reconnect to XMPP server

### DIFF
--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -755,8 +755,9 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
         d->streamManagementEnabled = true;
         enableStreamManagement(true);
-        // we are connected now
+        // TODO (lucioa): force set session started to true due to wrong resume data received in stanzas
         d->sessionStarted = true;
+        // we are connected now
         Q_EMIT connected();
     } else if (QXmppStreamManagementResumed::isStreamManagementResumed(nodeRecv)) {
         QXmppStreamManagementResumed streamManagementResumed;
@@ -767,9 +768,10 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
         d->streamManagementEnabled = true;
         enableStreamManagement(false);
+        // TODO (lucioa): force set session started to true due to wrong resume data received in stanzas
+        d->sessionStarted = true;
         // we are connected now
         // TODO: The stream was resumed. Therefore, we should not send presence information or request the roster.
-        d->sessionStarted = true;
         Q_EMIT connected();
     } else if (QXmppStreamManagementFailed::isStreamManagementFailed(nodeRecv)) {
         if (d->isResuming) {
@@ -792,8 +794,9 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
             d->sessionStarted = true;
             Q_EMIT connected();
         } else {
-            // we are connected now, but stream management is disabled
+            // TODO (lucioa): force set session started to true due to wrong resume data received in stanzas
             d->sessionStarted = true;
+            // we are connected now, but stream management is disabled
             Q_EMIT connected();
         }
     }

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -220,11 +220,13 @@ QXmppConfiguration &QXmppOutgoingClient::configuration()
 
 void QXmppOutgoingClient::connectToHost()
 {
+    // TODO (lucioa): disabled as we can't connect to resumeHost received in stanzas (srvxmppngprod01.internal.cloudapp.net)
+    //
     // if a host for resumption is available, connect to it
-    if (d->canResume && !d->resumeHost.isEmpty() && d->resumePort) {
-        d->connectToHost(d->resumeHost, d->resumePort);
-        return;
-    }
+    // if (d->canResume && !d->resumeHost.isEmpty() && d->resumePort) {
+    //     d->connectToHost(d->resumeHost, d->resumePort);
+    //     return;
+    // }
 
     // if an explicit host was provided, connect to it
     if (!d->config.host().isEmpty() && d->config.port()) {

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -756,6 +756,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
         d->streamManagementEnabled = true;
         enableStreamManagement(true);
         // we are connected now
+        d->sessionStarted = true;
         Q_EMIT connected();
     } else if (QXmppStreamManagementResumed::isStreamManagementResumed(nodeRecv)) {
         QXmppStreamManagementResumed streamManagementResumed;
@@ -768,6 +769,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
         enableStreamManagement(false);
         // we are connected now
         // TODO: The stream was resumed. Therefore, we should not send presence information or request the roster.
+        d->sessionStarted = true;
         Q_EMIT connected();
     } else if (QXmppStreamManagementFailed::isStreamManagementFailed(nodeRecv)) {
         if (d->isResuming) {
@@ -791,6 +793,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
             Q_EMIT connected();
         } else {
             // we are connected now, but stream management is disabled
+            d->sessionStarted = true;
             Q_EMIT connected();
         }
     }


### PR DESCRIPTION
This fixes AB#115566 Can't reconnect to XMPP server after loosing internet connection

**Problem**
QXMPP 1.6.1 library is reading resume data received from server stanzas.
The values received doesn't allow XMPP client to reconnect, due to not able to connect to resume host received (**srvxmppngprod01.internal.cloudapp.net**), as well as **isConnected()** checking for **sessionStarted** variable set, which wasn't happening on reconnection

**Solution**
Do not use resumeHost for reconnection
Set **sessionStarted** values to **true** in all cases when connected

**Additional changes**
Add random delays for reconnections as we already did before in 0.9.X library