### PR TITLE
AB#126881: force launch reconnection timer when stream has disconnected

### DIFF
--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -964,7 +964,10 @@ void QXmppClient::_q_streamConnected()
 void QXmppClient::_q_streamDisconnected()
 {
    // schedule reconnect if not already scheduled
-    if (!d->receivedConflict && !d->reconnectionTimer->isActive()) {
+    if (!d->receivedConflict
+        && !d->reconnectionTimer->isActive()
+        && d->stream->configuration().autoReconnectionEnabled()
+        && d->clientPresence.type() == QXmppPresence::Available) {
         qDebug() << Q_FUNC_INFO << "reconnection timer not active, relaunching...";
         d->reconnectionTimer->start(d->getNextReconnectTime());
         d->reconnectionTries++;

--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -963,6 +963,13 @@ void QXmppClient::_q_streamConnected()
 
 void QXmppClient::_q_streamDisconnected()
 {
+   // schedule reconnect if not already scheduled
+    if (!d->receivedConflict && !d->reconnectionTimer->isActive()) {
+        qDebug() << Q_FUNC_INFO << "reconnection timer not active, relaunching...";
+        d->reconnectionTimer->start(d->getNextReconnectTime());
+        d->reconnectionTries++;
+    }
+
     // notify managers
     Q_EMIT disconnected();
     Q_EMIT stateChanged(QXmppClient::DisconnectedState);


### PR DESCRIPTION
AB#126881 [Receiver] [XMPP]Not recover 6-digits meeting after server outage

Modify **QXmppClient** logic so it always tries to reconnect when XMPP stream is closed and reconnection timer is not active

This fixes 2 issues found while checking receiver against muxi:

- When connection to server was timed out (after 20 seconds), reconnection timer wasn't started.
- When an XMPP error happened while connecting (i.e.: credentials error), reconnection timer wasn't started.
